### PR TITLE
Change shibboleth attributes to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ all:
   shibboleth_translator_groups: 'shib-translators'
 ```
 
+In `apps/qubit/config/app.yml` add correct Shibboleth attribute mappings, e.g.
+```
+all:
+  shibboleth_attribute_mail: 'mail'
+  shibboleth_attribute_eppn: 'eppn'
+```
+
+
 Features
 -------------------
 - login via Shibboleth

--- a/lib/sfDariahShibUser.class.php
+++ b/lib/sfDariahShibUser.class.php
@@ -100,7 +100,7 @@ class sfDariahShibUser extends myUser implements Zend_Acl_Role_Interface
 
     $user = new QubitUser();
     $user->username = $username;
-    $user->email = $params['mail'];
+    $user->email = $params[sfConfig::get('app_shibboleth_attribute_mail')];
     $user->save();
     $user->setPassword($password);
 
@@ -165,7 +165,7 @@ class sfDariahShibUser extends myUser implements Zend_Acl_Role_Interface
 
     $params = $request->getPathInfoArray();
     // Warning: does not support federation!
-    $usernameparts = explode("@", $params['eppn']);
+    $usernameparts = explode("@", $params[sfConfig::get('app_shibboleth_attribute_eppn')]);
     $username = $usernameparts[0];
 
     return $username;

--- a/modules/user/actions/loginAction.class.php
+++ b/modules/user/actions/loginAction.class.php
@@ -72,7 +72,7 @@ class UserLoginAction extends sfAction
 
     if (strlen($apache_params['Shib-Session-Index'])>=8) 
     {
-      if ($this->context->user->authenticate($apache_params['mail'],'',$request))
+      if ($this->context->user->authenticate($apache_params[sfConfig::get('app_shibboleth_attribute_mail')],'',$request))
       {
         if (null !== $next = $this->form->getValue('next'))
         {


### PR DESCRIPTION
Add a configuration option for specifying what the shibboleth attributes
that are used for eppn and mail in case they are different